### PR TITLE
Minor updates to review API routes

### DIFF
--- a/api/routes/reviews.js
+++ b/api/routes/reviews.js
@@ -74,7 +74,7 @@ router.patch('/:review_id', (req, res) => {
       } else if (field.startsWith('gf')) {
         val = req.body[field] || req.body[field] === 'true';
       } else {
-        val = parseInt(req.body[field]);
+        val = parseInt(req.body[field]) || null;
       }
 
       query.values.push(val);

--- a/api/utils/db.js
+++ b/api/utils/db.js
@@ -23,6 +23,7 @@ module.exports = {
     playerInteraction: '"playerInteraction"',
     replayValue: '"replayValue"',
     complexity: '"complexity"',
+    artAndStyle: '"artAndStyle"',
     gfKids: '"gfKids"',
     gfTeens: '"gfTeens"',
     gfAdults: '"gfAdults"',


### PR DESCRIPTION
### This PR includes:
- Addition of `artAndStyle` review category to API endpoints
  - NOTE: this relies on changes to the DB schema in PR #17 
- Added handling of null values when updating a review
  - This fixes an issue when updating a review with only some of the ratings filled out