### PR TITLE
Fix reviews game page

### DIFF
--- a/client/src/actions/index.js
+++ b/client/src/actions/index.js
@@ -110,10 +110,17 @@ export const getGames = () => {
 const errorGame = createAction("ERROR_GAME")
 const fetchingGame = createAction("FETCHING_GAME")
 const receiveGame = createAction("RECEIVE_GAME")
+const resetGameState = createAction("RESET_GAME")
 
 export const gameLoading = () => {
   return dispatch => {
     dispatch(fetchingGame())
+  }
+}
+
+export const resetGame = () => {
+  return dispatch => {
+    dispatch(resetGameState())
   }
 }
 
@@ -277,6 +284,14 @@ export const getGameReviews = () => {
       .catch(err => {
         dispatch(errorReceiveReviews(err))
       });
+  }
+}
+
+const resetReviewState = createAction("RESET_REVIEW")
+
+export const resetReview = () => {
+  return (dispatch) => {
+    dispatch(resetReviewState())
   }
 }
 

--- a/client/src/components/Game.jsx
+++ b/client/src/components/Game.jsx
@@ -6,7 +6,7 @@ import Paper from '@material-ui/core/Paper';
 import Grid from '@material-ui/core/Grid';
 import { Redirect } from "react-router-dom";
 import { Spinner } from 'react-bootstrap';
-import { getGame, gameLoading } from '../actions/index'
+import { getGame, gameLoading, resetGame } from '../actions/index'
 
 import { Reviews } from './Review'
 import { AddToCollection } from './AddToCollection';
@@ -15,6 +15,22 @@ class _Game extends React.Component {
 
   constructor(props) {
     super(props)
+  }
+
+  componentDidMount() {
+    this.unlisten = this.props.history.listen((location, action) => {
+      this.props.resetGame()
+      this.props.gameLoading()
+      this.props.getGame(this.props.match.params.id)
+    });
+
+    this.props.resetGame()
+    this.props.gameLoading()
+    this.props.getGame(this.props.match.params.id)
+  }
+
+  componentWillUnmount() {
+    this.unlisten()
   }
 
   render() {
@@ -36,12 +52,6 @@ class _Game extends React.Component {
     // at this point, there is no token & id in localStorage, so route should redirect to login
     if(!user.isReceived && !user.isFetching && !user.isNew) {
       return <Redirect to='/login' />
-    }
-
-    // No game from games state, fetch game
-    if (!game.isFetching && !game.isReceived) {
-      this.props.gameLoading()
-      this.props.getGame(this.props.match.params.id)
     }
 
     if (game.isReceived) {
@@ -131,6 +141,6 @@ export const Game = connect(state => {
   return { game, user }
 }, dispatch => {
   return bindActionCreators({
-    getGame, gameLoading
+    getGame, gameLoading, resetGame
   }, dispatch)
 })(_Game)

--- a/client/src/components/Games.jsx
+++ b/client/src/components/Games.jsx
@@ -20,6 +20,12 @@ const GamePageTotal = (from, to, size) => (
   </span>
 )
 
+const rowEvents = {
+  onClick: (e, row, rowIndex) => {
+    this._setGame(row)
+  }
+}
+
 // Other Review table columns
 const GamesColumns = [{
   dataField: 'id',
@@ -133,21 +139,6 @@ class _Games extends React.Component {
   }
 
   _setGame(game) {
-    this.props.getSetGameState({
-      id: game.id,
-      isUserCreated: game.isUserCreated,
-      identifierID: game.identifierID,
-      name: game.name,
-      publisher: game.publisher,
-      year: game.year,
-      minPlaytime: game.minPlaytime,
-      minPlayers: game.minPlayers,
-      maxPlayers: game.maxPlayers,
-      minAge: game.minAge,
-      imgFileName: game.imgFileName,
-      description: game.description,
-      categories: game.categories,
-    })
     this.setState({ viewGame: true, gameID: game.id })
   }
 
@@ -158,6 +149,7 @@ class _Games extends React.Component {
 
     let tableData = []
     let notifier
+    let setGame = this._setGame // gives access to this._setGame in bootstrap table
 
     // At beginning of user state, check to see if user state action has been dispatched
     if (user.isNew) {
@@ -188,12 +180,6 @@ class _Games extends React.Component {
     // Create error notification
     if (games.error !== null) {
       notifier = <Notifier type="ERROR_GAMES" />
-    }
-
-    const rowEvents = {
-      onClick: (e, row, rowIndex) => {
-        this._setGame(row)
-      }
     }
 
     // Push reviews to table data
@@ -277,6 +263,7 @@ class _Games extends React.Component {
             </Grid>
             <Grid item xs={12}>
               <Button
+                onClick={() => setGame(game)}
                 variant="info"
                 size="sm"
                 type="submit"
@@ -296,7 +283,6 @@ class _Games extends React.Component {
             data={tableData}
             columns={GamesColumns}
             search
-            rowEvents={rowEvents}
           >
             {
               props =>

--- a/client/src/components/Games.jsx
+++ b/client/src/components/Games.jsx
@@ -20,12 +20,6 @@ const GamePageTotal = (from, to, size) => (
   </span>
 )
 
-const rowEvents = {
-  onClick: (e, row, rowIndex) => {
-    this._setGame(row)
-  }
-}
-
 // Other Review table columns
 const GamesColumns = [{
   dataField: 'id',

--- a/client/src/components/Review.jsx
+++ b/client/src/components/Review.jsx
@@ -3,9 +3,9 @@ import { connect } from 'react-redux'
 import { bindActionCreators } from 'redux'
 
 // Import Actions
-import { getGameReviews, updateReview, submitReview, deleteReview, getResetReviewNotif } from '../actions/index'
+import { getGameReviews, updateReview, submitReview, deleteReview, getResetReviewNotif, resetReview } from '../actions/index'
 
-import { Form, Button, InputGroup } from 'react-bootstrap'
+import { Form, Button, InputGroup, Spinner } from 'react-bootstrap'
 import Grid from '@material-ui/core/Grid';
 import Rating from '@material-ui/lab/Rating';
 import Checkbox from '@material-ui/core/Checkbox';
@@ -335,6 +335,7 @@ class _Reviews extends React.Component {
 
   // Get reviews when component loads
   componentDidMount() {
+    this.props.resetReview()
     this.props.getGameReviews()
   }
 
@@ -409,11 +410,21 @@ class _Reviews extends React.Component {
 
   render() {
 
-    const { reviews } = this.props
+    const { reviews, user } = this.props
 
     var formDisabled = false
     var tableData = []
     var notifier = <div />
+
+    if (user.isNew || user.isFetching) {
+      return (
+        <div className="spinner-wrapper">
+          <div className="d-flex justify-content-center">
+            <Spinner animation="border" />
+          </div>
+        </div>
+      )
+    }
 
     if (reviews.userReviewed && !this.state.editReview) {
       formDisabled = true
@@ -752,10 +763,10 @@ class _Reviews extends React.Component {
 }
 
 export const Reviews = connect(state => {
-  const { reviews } = state
-  return { reviews }
+  const { reviews, user } = state
+  return { reviews, user  }
 }, dispatch => {
   return bindActionCreators({
-    getGameReviews, updateReview, submitReview, deleteReview, getResetReviewNotif
+    getGameReviews, updateReview, submitReview, deleteReview, getResetReviewNotif, resetReview
   }, dispatch)
 })(_Reviews)

--- a/client/src/css/App.css
+++ b/client/src/css/App.css
@@ -110,6 +110,10 @@
   table-layout: unset;
 }
 
+.Comments {
+  width: 60%;
+}
+
 .CommentsWrapper {
   padding: 0px 5px 5px 5px !important;
   margin: 0px 10px 10px 10px !important;

--- a/client/src/reducers/reviews.js
+++ b/client/src/reducers/reviews.js
@@ -121,6 +121,17 @@ export const reviews = (state = reviewsState, action) => {
         error: null
       })
 
+    case "RESET_REVIEW":
+      return Object.assign({}, state, {
+        isFetching: false,
+        isReceived: false,
+        error: null,
+        notifType: null,
+        userReviewed: false,
+        userReview: {},
+        rows: []
+      })
+
     case "RESET_NOTIF":
       return Object.assign({}, state, {
         notifType: null


### PR DESCRIPTION
### What's in this PR:
- Fixes review table css
- Fixes game state issue. Previously games rowEvent would pass the game data to the game state and redirect to the page. This created issues when refreshing the page with a game id change in the URL. A history listener now watches for a URL change and updates accordingly. 
- Deletes rowEvents. The "see reviews" button before had no functionality, clicking anywhere within the game row would redirect to the game page. Now only the button will redirect to the game page. 
- Adds user state to Reviews component. Review API calls will block until the user state has been determined if a refresh occurs on a game page. 
